### PR TITLE
Add MDL0 vertex attribute compression

### DIFF
--- a/berrybush/blender/brresexport.py
+++ b/berrybush/blender/brresexport.py
@@ -11,7 +11,8 @@ import numpy as np
 from .common import ( # pylint: disable=unused-import
     MTX_TO_BONE, MTX_FROM_BONE, MTX_TO_BRRES, LOG_PATH,
     solidView, restoreView, limitIncludes, usedMatSlots, makeUniqueName, foreachGet, getLayerData,
-    getLoopVertIdcs, getLoopFaceIdcs, getFaceMatIdcs, getPropName, drawCheckedProp
+    getLoopVertIdcs, getLoopFaceIdcs, getFaceMatIdcs, getPropName, drawCheckedProp,
+    simplifyLayerData
 )
 from .material import AlphaSettings, DepthSettings, LightChannelSettings, MiscMatSettings
 from .tev import TevSettings, TevStageSettings
@@ -307,12 +308,7 @@ class BRRESMdlExporter():
             return None
         group = groupType(f"{layer.id_data.name}__{layer.name}")
         self.model.vertGroups[groupType].append(group)
-        ndims = group.ctype.ndims
-        # pad/crop data if wrong # of dimensions
-        paddedData = np.zeros((len(data), ndims))
-        data = data[:, :ndims]
-        paddedData[:, :data.shape[1]] = data
-        group.setData(paddedData)
+        group.setArr(data)
         return group
 
     def _getParentAndApplyTransform(self, mesh: bpy.types.Mesh, obj: bpy.types.Object):
@@ -427,12 +423,13 @@ class BRRESMdlExporter():
         psns, unqPsnInv = np.unique(psns, return_inverse=True, axis=0)
         psnGroup = mdl0.PsnGroup(mesh.name)
         self.model.vertGroups[mdl0.PsnGroup].append(psnGroup)
-        psnGroup.setData(psns)
+        psnGroup.setArr(psns)
         # generate normal group
+        nrms = simplifyLayerData(nrms)
         nrms, unqNrmInv = np.unique(nrms, return_inverse=True, axis=0)
         nrmGroup = mdl0.NrmGroup(mesh.name)
         self.model.vertGroups[mdl0.NrmGroup].append(nrmGroup)
-        nrmGroup.setData(nrms)
+        nrmGroup.setArr(nrms)
         # generate color & uv groups
         try:
             # brres mesh attributes may be deleted by modifiers, so try to get from original mesh

--- a/berrybush/blender/brresimport.py
+++ b/berrybush/blender/brresimport.py
@@ -391,7 +391,7 @@ class BRRESMdlImporter():
                     for s, group in slots.items():
                         # get data for this group & add it to existing data, padding if necessary
                         # (if group doesn't have all dimensions stored, e.g., rgb instead of rgba)
-                        groupData = group.getAttr().pad(group.arr())
+                        groupData = group.arr.copy()
                         try:
                             curSlotData = slotData[s]
                             # add offsets to commands to compensate for expanded vertex groups

--- a/berrybush/blender/common.py
+++ b/berrybush/blender/common.py
@@ -274,6 +274,7 @@ def getLayerData(mesh: bpy.types.Mesh, layerNames: tuple[str], isUV = False, uni
                     layerData = foreachGet(layer.data, "vector", layerCompCount)
         # then, process data & add to list
         if layerData is not None:
+            layerData = simplifyLayerData(layerData)
             if isUV: # flip uvs
                 layerData[:, 1] = 1 - layerData[:, 1]
             else: # clamp colors
@@ -282,3 +283,9 @@ def getLayerData(mesh: bpy.types.Mesh, layerNames: tuple[str], isUV = False, uni
                 layerData, layerIdcs = np.unique(layerData, return_inverse=True, axis=0)
         allData.append((layer, layerData, layerIdcs))
     return allData
+
+
+def simplifyLayerData(data: np.ndarray):
+    """Simplify data for a mesh attribute for the sake of file size optimization."""
+    scale = 1 << 14
+    return (data * scale).round() / scale


### PR DESCRIPTION
Attribute format specifiers for MDL0 vertex attribute groups are now detected automatically rather than read & stored from BRRES files, and some basic quantization (to the nearest 2^-14) has been added during Blender export. This all means that mesh data exported from Blender is now significantly more compressed on average (the W1 map model dropping from 3.53 MB with the previous method to just 2.23 now, compared to its regular retail size of 1.55).